### PR TITLE
Bug Fix: Encode url argument

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -24,8 +24,10 @@ app.get("/bounceme", (req, res) => {
     : res.status(400).json({ error: "no url" });
 });
 
-const _getRedirectUrl = req =>
-  `${process.env.AUTH_BOUNCE_URL}?url=https://${req.get('host')}${req.headers['x-starphleet-originalurl']}`;
+const _getRedirectUrl = req => {
+  const _encodedURI = encodeURIComponent(`https://${req.get('host')}${req.headers['x-starphleet-originalurl']}`);
+  return `${process.env.AUTH_BOUNCE_URL}?url=${_encodedURI}`;
+};
 
 /** Auth bounce */
 app.all("*", (req, res) => process.env.AUTH_BOUNCE_URL


### PR DESCRIPTION
- Users reported that multiple param arguments to apps were getting lost
after the auth sequence. That is because the "url" param passed to the
bounce app was not encoded